### PR TITLE
fix(eslint-plugin): support JSX attrs in allowTypedFunctionExpressions

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -172,6 +172,10 @@ functionWithObjectArg({
     return 1;
   },
 });
+
+const Comp: FC = () => {
+  return <button onClick={() => {}} />;
+};
 ```
 
 ### `allowHigherOrderFunctions`

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -40,6 +40,51 @@ function isPropertyDefinitionWithTypeAnnotation(
 /**
  * Checks if a node belongs to:
  * ```
+ * foo(() => 1)
+ * ```
+ */
+function isFunctionArgument(
+  parent: TSESTree.Node,
+  callee?: FunctionExpression,
+): parent is TSESTree.CallExpression {
+  return (
+    parent.type === AST_NODE_TYPES.CallExpression &&
+    // make sure this isn't an IIFE
+    parent.callee !== callee
+  );
+}
+
+/**
+ * Checks if a node is an expression in a JSX attribute assignment
+ * ```
+ * <Comp x={...} />
+ * ```
+ */
+function isJSXAttribute(
+  node: TSESTree.Node,
+): node is TSESTree.JSXExpressionContainer | TSESTree.JSXSpreadAttribute {
+  return (
+    node.type === AST_NODE_TYPES.JSXExpressionContainer ||
+    node.type === AST_NODE_TYPES.JSXSpreadAttribute
+  );
+}
+
+function isTypedParent(
+  parent: TSESTree.Node,
+  callee?: FunctionExpression,
+): boolean {
+  return (
+    isTypeAssertion(parent) ||
+    isVariableDeclaratorWithTypeAnnotation(parent) ||
+    isPropertyDefinitionWithTypeAnnotation(parent) ||
+    isFunctionArgument(parent, callee) ||
+    isJSXAttribute(parent)
+  );
+}
+
+/**
+ * Checks if a node belongs to:
+ * ```
  * new Foo(() => {})
  *         ^^^^^^^^
  * ```
@@ -78,13 +123,7 @@ function isPropertyOfObjectWithType(
     return false;
   }
 
-  return (
-    isTypeAssertion(parent) ||
-    isPropertyDefinitionWithTypeAnnotation(parent) ||
-    isVariableDeclaratorWithTypeAnnotation(parent) ||
-    isFunctionArgument(parent) ||
-    isPropertyOfObjectWithType(parent)
-  );
+  return isTypedParent(parent) || isPropertyOfObjectWithType(parent);
 }
 
 /**
@@ -124,23 +163,6 @@ function doesImmediatelyReturnFunctionExpression({
   return (
     body.type === AST_NODE_TYPES.ArrowFunctionExpression ||
     body.type === AST_NODE_TYPES.FunctionExpression
-  );
-}
-
-/**
- * Checks if a node belongs to:
- * ```
- * foo(() => 1)
- * ```
- */
-function isFunctionArgument(
-  parent: TSESTree.Node,
-  callee?: FunctionExpression,
-): parent is TSESTree.CallExpression {
-  return (
-    parent.type === AST_NODE_TYPES.CallExpression &&
-    // make sure this isn't an IIFE
-    parent.callee !== callee
   );
 }
 
@@ -194,11 +216,8 @@ function isTypedFunctionExpression(
   }
 
   return (
-    isTypeAssertion(parent) ||
-    isVariableDeclaratorWithTypeAnnotation(parent) ||
-    isPropertyDefinitionWithTypeAnnotation(parent) ||
+    isTypedParent(parent, node) ||
     isPropertyOfObjectWithType(parent) ||
-    isFunctionArgument(parent, node) ||
     isConstructorArgument(parent)
   );
 }

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -180,6 +180,46 @@ class App {
       `,
       options: [{ allowTypedFunctionExpressions: true }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/7552
+    {
+      code: `
+const Comp: FC = () => {
+  return <button onClick={() => {}} />;
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: `
+const Comp: FC = () => {
+  return <Button on={{ click: () => {} }} />;
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: `
+const Comp: FC = () => {
+  return <button {...{ onClick: () => {} }} />;
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
     // https://github.com/typescript-eslint/typescript-eslint/issues/525
     {
       code: `
@@ -974,6 +1014,28 @@ const x: Foo = {
           endLine: 4,
           column: 3,
           endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: `
+const Comp = (): JSX.Element => {
+  return <button onClick={() => {}} />;
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: false }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 30,
+          endColumn: 32,
         },
       ],
     },


### PR DESCRIPTION
TEMPORARY FORK PR for demo and notes

Addresses https://github.com/typescript-eslint/typescript-eslint/issues/7552

https://typescript-eslint.io/contributing/pull-requests

## PR Checklist

- [X] Addresses an existing open issue: fixes #7552
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Adds support for JSX attributes to the `allowTypedFunctionExpressions` option of the `explicit-function-return-type` rule
- DRYes out code between common and recursive object-property cases
